### PR TITLE
Execute bubble_sort with list copy as input

### DIFF
--- a/Week_09.ipynb
+++ b/Week_09.ipynb
@@ -495,7 +495,7 @@
     "nums = [randint(0, 100) for x in range(5000)]\n",
     "\n",
     "start_time = time.time()  # tracking time bubble sort\n",
-    "bubbleSort(nums)\n",
+    "bubbleSort(nums[:])\n",
     "end_time = time.time() - start_time\n",
     "print('Elapsed time for Bubble Sort: {}'.format(end_time))\n",
     "\n",


### PR DESCRIPTION
If bubble_sort doesn't get a list copy, insertion_sort will
always run on a sorted list and runtime comparison is meaningless